### PR TITLE
Fix arguments order in Store.find/1

### DIFF
--- a/lib/event_bus_postgres/store.ex
+++ b/lib/event_bus_postgres/store.ex
@@ -80,7 +80,7 @@ defmodule EventBus.Postgres.Store do
   Find an event
   """
   def find(id) do
-    case Repo.get(id, Event) do
+    case Repo.get(Event, id) do
       nil -> nil
       event -> Event.to_eb_event(event)
     end


### PR DESCRIPTION
I should add tests to check that other things aren't broken. I've found this bug while I was trying to use `Store` functions.