### PR TITLE
Fix Store.delete_expired/0 function

### DIFF
--- a/lib/event_bus_postgres/store.ex
+++ b/lib/event_bus_postgres/store.ex
@@ -113,7 +113,7 @@ defmodule EventBus.Postgres.Store do
     query =
       from(
         e in Event,
-        where: fragment("? + ? >= ?", e.occurred_at, e.ttl, ^now)
+        where: fragment("? + ? <= ?", e.occurred_at, e.ttl, ^now)
       )
 
     Repo.delete_all(query)


### PR DESCRIPTION
The deletion was messed up so we used to delete only the newest events
instead of the expired ones.